### PR TITLE
updates lando-messaging to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lando-messaging==1.0.0
+lando-messaging==2.0.0
 requests==2.20.1


### PR DESCRIPTION
This is to support lando changes that adds a new message type sent to lando worker VMs.
See Duke-GCB/lando#200.